### PR TITLE
fix: discount terminal value back to start_year per 2DII Limited Visibility paper

### DIFF
--- a/R/calc_annual_profts.R
+++ b/R/calc_annual_profts.R
@@ -9,6 +9,9 @@
 #' @param shock_scenario Character. A string that indicates which
 #'   of the scenarios included in the analysis should be used to set the
 #'   late & sudden technology trajectories.
+#' @param start_year Numeric, holding start year of analysis. Used to pull the
+#'   terminal value back to present value as per the 2DII "Limited Visibility"
+#'   methodology (Figure 1).
 #' @param end_year Numeric, holding end year of analysis.
 #' @param discount_rate Numeric, the discount rate
 #' @param growth_rate Numeric, that holds the terminal growth rate of profits
@@ -18,12 +21,14 @@
 calculate_annual_profits <- function(data,
                                      baseline_scenario,
                                      shock_scenario,
+                                     start_year,
                                      end_year,
                                      discount_rate,
                                      growth_rate) {
   data <- data %>%
     dividend_discount_model(discount_rate = discount_rate) %>%
     calculate_terminal_value(
+      start_year = start_year,
       end_year = end_year,
       growth_rate = growth_rate,
       discount_rate = discount_rate
@@ -62,12 +67,20 @@ dividend_discount_model <- function(data, discount_rate) {
 
 
 
+# Terminal value follows the stable-growth formula from the 2DII paper
+# "Limited Visibility" (https://2degrees-investing.org/resource/limited-visibility-the-current-state-of-corporate-disclosure-on-long-term-risks/).
+#   Appendix 3, Figure 1:  TV_at_end_year = CF[end_year] * (1 + g) / (r - g)
+#   Main body, Figure 1:   Discounted TV  = TV_at_end_year / (1 + r)^(end_year - start_year)
+# The pull-back factor `(1 + r)^(end_year - start_year)` is required so the
+# terminal-value row can be summed with the other already-discounted flows
+# (Appendix 3: "explicit value" and "extrapolated value" are summed with "all
+# values discounted").
 calculate_terminal_value <- function(data,
+                                     start_year,
                                      end_year,
                                      growth_rate,
                                      discount_rate) {
-  # the calculation follows the formula described in the 2DII paper "Limited
-  # Visibility", available under https://2degrees-investing.org/resource/limited-visibility-the-current-state-of-corporate-disclosure-on-long-term-risks/
+  horizon <- end_year - start_year
   terminal_value <- data %>%
     dplyr::filter(.data$year == .env$end_year) %>%
     dplyr::mutate(
@@ -75,9 +88,11 @@ calculate_terminal_value <- function(data,
       net_profits_baseline = .data$net_profits_baseline * (1 + .env$growth_rate),
       net_profits_ls = .data$net_profits_ls * (1 + .env$growth_rate),
       discounted_net_profit_baseline = .data$net_profits_baseline /
-        (.env$discount_rate - .env$growth_rate),
+        (.env$discount_rate - .env$growth_rate) /
+        (1 + .env$discount_rate)^.env$horizon,
       discounted_net_profit_ls = .data$net_profits_ls /
-        (.env$discount_rate - .env$growth_rate)
+        (.env$discount_rate - .env$growth_rate) /
+        (1 + .env$discount_rate)^.env$horizon
     ) %>%
     # ADO3112: All columns that reflect a change over time are set to NA, as
     # they cannot be extrapolated from the start_year to end_year period. All

--- a/R/run_trisk.R
+++ b/R/run_trisk.R
@@ -166,6 +166,7 @@ run_trisk_model <- function(assets_data,
     data = company_net_profits,
     baseline_scenario = baseline_scenario,
     shock_scenario = target_scenario,
+    start_year = start_year,
     end_year = end_analysis,
     discount_rate = discount_rate,
     growth_rate = growth_rate

--- a/man/calculate_annual_profits.Rd
+++ b/man/calculate_annual_profits.Rd
@@ -8,6 +8,7 @@ calculate_annual_profits(
   data,
   baseline_scenario,
   shock_scenario,
+  start_year,
   end_year,
   discount_rate,
   growth_rate
@@ -23,6 +24,10 @@ baseline technology trajectories.}
 \item{shock_scenario}{Character. A string that indicates which
 of the scenarios included in the analysis should be used to set the
 late & sudden technology trajectories.}
+
+\item{start_year}{Numeric, holding start year of analysis. Used to pull the
+terminal value back to present value as per the 2DII "Limited Visibility"
+methodology (Figure 1).}
 
 \item{end_year}{Numeric, holding end year of analysis.}
 

--- a/tests/testthat/test_terminal_value.R
+++ b/tests/testthat/test_terminal_value.R
@@ -1,0 +1,86 @@
+library(testthat)
+library(dplyr)
+
+# Terminal value must implement the 2DII "Limited Visibility" stable-growth
+# formula with the pull-back to start_year:
+#   TV_discounted = CF[end_year] * (1 + g) / (r - g) / (1 + r)^(end_year - start_year)
+
+test_that("calculate_terminal_value applies Gordon perpetuity and pulls back to start_year", {
+  start_year <- 2020
+  end_year <- 2030
+  discount_rate <- 0.08
+  growth_rate <- 0.03
+
+  fake <- tibble::tibble(
+    asset_id = 1, company_id = 1, sector = "power", technology = "coal",
+    year = start_year:end_year,
+    net_profits_baseline = 100,
+    net_profits_ls = 80
+  )
+
+  with_tv <- trisk.model:::calculate_terminal_value(
+    fake,
+    start_year = start_year,
+    end_year = end_year,
+    growth_rate = growth_rate,
+    discount_rate = discount_rate
+  )
+
+  tv_row <- with_tv %>% dplyr::filter(.data$year == end_year + 1)
+
+  horizon <- end_year - start_year
+  expected_baseline <- 100 * (1 + growth_rate) / (discount_rate - growth_rate) /
+    (1 + discount_rate)^horizon
+  expected_ls <- 80 * (1 + growth_rate) / (discount_rate - growth_rate) /
+    (1 + discount_rate)^horizon
+
+  expect_equal(tv_row$discounted_net_profit_baseline, expected_baseline, tolerance = 1e-10)
+  expect_equal(tv_row$discounted_net_profit_ls, expected_ls, tolerance = 1e-10)
+  expect_equal(tv_row$net_profits_baseline, 100 * (1 + growth_rate))
+  expect_equal(tv_row$net_profits_ls, 80 * (1 + growth_rate))
+})
+
+test_that("calculate_annual_profits end-to-end produces a decreasing discount factor in the terminal row", {
+  start_year <- 2020
+  end_year <- 2030
+  discount_rate <- 0.08
+  growth_rate <- 0.03
+
+  fake <- tibble::tibble(
+    asset_id = 1, company_id = 1, sector = "power", technology = "coal",
+    year = start_year:end_year,
+    net_profits_baseline = 100,
+    net_profits_ls = 80
+  )
+
+  out <- trisk.model:::calculate_annual_profits(
+    data = fake,
+    baseline_scenario = "x", shock_scenario = "y",
+    start_year = start_year,
+    end_year = end_year,
+    discount_rate = discount_rate,
+    growth_rate = growth_rate
+  )
+
+  # Implied per-row discount factor relative to the undiscounted net profit.
+  out <- out %>%
+    dplyr::mutate(implied_factor = .data$discounted_net_profit_baseline / .data$net_profits_baseline)
+
+  last_explicit_factor <- out$implied_factor[out$year == end_year]
+  terminal_factor <- out$implied_factor[out$year == end_year + 1]
+
+  # With proper pull-back, terminal factor equals (1 / (r-g)) * (1 / (1+r)^horizon),
+  # which for r=0.08, g=0.03, horizon=10 is about 9.27. It must be larger than the
+  # last explicit year's factor (1/(1+r)^10 ~ 0.463) — that's expected because the
+  # terminal row represents an infinite stream, not a single year. The critical
+  # property is that it is NOT equal to 1/(r-g) (20x) which would signal missing
+  # pull-back.
+  horizon <- end_year - start_year
+  expect_equal(
+    terminal_factor,
+    (1 / (discount_rate - growth_rate)) / (1 + discount_rate)^horizon,
+    tolerance = 1e-10
+  )
+  expect_lt(terminal_factor, 1 / (discount_rate - growth_rate))
+  expect_gt(terminal_factor, last_explicit_factor)
+})


### PR DESCRIPTION
## Summary

The Gordon stable-growth formula `CF * (1+g) / (r-g)` produces a terminal value expressed **at time `end_year`**, not at time `start_year`. The 2DII *Limited Visibility* paper (cited in `calculate_terminal_value`'s comment) explicitly shows this terminal value being further discounted back to present value before being summed with the other already-discounted flows (main-body Figure 1; Appendix 3 states *"all values are discounted"*).

Previously the code placed the raw Gordon perpetuity into the series at `year = end_year + 1` without the pull-back factor. This caused the terminal row's implied discount factor to be `1 / (r−g)` — greater than 1 for typical `r` and `g` — instead of the correct `1 / ((r−g) × (1+r)^(end_year−start_year))`. The terminal contribution was inflated by roughly `(1+r)^(end_year−start_year)` (~6.6× for `r=7%`, horizon = 28 years).

## Fix

- `calculate_terminal_value()` now takes `start_year` and divides the Gordon perpetuity value by `(1 + discount_rate)^(end_year − start_year)` so the terminal row sits at present value.
- `calculate_annual_profits()` threads `start_year` through; `run_trisk_model()` call site updated.
- New unit test file `tests/testthat/test_terminal_value.R` pins both the per-row formula and the end-to-end implied-discount-factor behaviour.

## Verification

On standard testdata with `r = 0.07`, `g = 0.03`, horizon = 28 (2022–2050):

| Year | Role | Implied discount factor | Expected |
| --- | --- | --- | --- |
| 2022 | start | 1.000 | `1 / (1+r)^0` |
| 2050 | last explicit | 0.150 | `1 / 1.07^28` ✓ |
| 2051 | terminal | 3.760 | `1 / (r−g) / 1.07^28` ✓ |

Previously the 2051 factor was `1/(r−g) = 25.0`.

## Test plan

- [x] `tests/testthat/test_terminal_value.R` passes (unit test of `calculate_terminal_value` + end-to-end via `calculate_annual_profits`)
- [x] Existing test suite passes (snapshot test remains gated behind `R_USE_TESTS=TRUE` and will need snapshot regeneration on main — out of scope for this PR)
- [x] End-to-end `run_trisk_model()` runs cleanly on bundled testdata

## Note on snapshot

`test_output_continuity.R` snapshot will change because NPV values legitimately change after the fix. The snapshot is skipped by default (`R_USE_TESTS != "TRUE"`), so CI is unaffected. Snapshot regeneration should be done as a separate follow-up commit on `main` once this lands.