### PR TITLE
fix(ADO 1943): size PD term grid to the analysis horizon

### DIFF
--- a/R/calc_pd_change_overall.R
+++ b/R/calc_pd_change_overall.R
@@ -50,14 +50,15 @@ calculate_pd_change_overall <- function(data,
   nesting_names <- c(colnames(data %>% dplyr::select(-.data$term)))
 
   data <- data %>%
-    # ADO 1943 - fixed term grid independent of portfolio terms; describes the
-    # overall trend of PDs, not a change in the portfolio. Extended 1:5 -> 1:10
-    # so bank loan portfolios with terms 6-10 years get non-NA PDs after the
-    # join in trisk.analysis (previously `term > 5` portfolio rows silently
-    # dropped to NA).
+    # ADO 1943 - term grid sized to the analysis horizon. Per-company PD
+    # trajectory by term; portfolio rows downstream join on (company_id, term).
+    # Cap at end_of_analysis - start_year + 1 because PD beyond the projection
+    # window has no economic basis here (terminal value handles beyond-horizon
+    # profits). Previously hardcoded 1:5 then 1:10 - any portfolio row with a
+    # term past that ceiling silently produced NA in the join in trisk.analysis.
     tidyr::complete(
       tidyr::nesting(!!!rlang::syms(nesting_names)),
-      term = 1:10
+      term = seq_len(end_of_analysis - start_year + 1)
     ) %>%
     dplyr::filter(!is.na(.data$term))
 

--- a/tests/testthat/test_pd_term_grid.R
+++ b/tests/testthat/test_pd_term_grid.R
@@ -1,0 +1,61 @@
+library(testthat)
+library(dplyr)
+
+# Regression: calculate_pd_change_overall used to hardcode term = 1:5, then
+# term = 1:10. Portfolio rows past the ceiling silently NA'd in the downstream
+# join in trisk.analysis. The fix sizes the term grid to the analysis horizon
+# (end_of_analysis - start_year + 1) so PDs cover the full projection window.
+
+test_that("calculate_pd_change_overall sizes term grid to the analysis horizon", {
+  start_year <- 2020
+  end_of_analysis <- 2035
+  expected_max_term <- end_of_analysis - start_year + 1  # 16
+
+  fake <- tibble::tibble(
+    year = start_year:end_of_analysis,
+    company_id = "co_1",
+    company_name = "Acme",
+    sector = "power",
+    debt_equity_ratio = 0.5,
+    volatility = 0.3,
+    discounted_net_profit_baseline = 100,
+    discounted_net_profit_ls = 80
+  )
+
+  pd <- trisk.model:::calculate_pd_change_overall(
+    fake,
+    shock_year = 2025,
+    start_year = start_year,
+    end_of_analysis = end_of_analysis,
+    risk_free_interest_rate = 0.02
+  )
+
+  expect_equal(max(pd$term), expected_max_term)
+  expect_equal(sort(unique(pd$term)), seq_len(expected_max_term))
+})
+
+test_that("calculate_pd_change_overall produces non-NA PDs for term > 10 (regression for ADO 1943)", {
+  fake <- tibble::tibble(
+    year = 2020:2035,
+    company_id = "co_1",
+    company_name = "Acme",
+    sector = "power",
+    debt_equity_ratio = 0.5,
+    volatility = 0.3,
+    discounted_net_profit_baseline = 100,
+    discounted_net_profit_ls = 80
+  )
+
+  pd <- trisk.model:::calculate_pd_change_overall(
+    fake,
+    shock_year = 2025,
+    start_year = 2020,
+    end_of_analysis = 2035,
+    risk_free_interest_rate = 0.02
+  )
+
+  long_term_rows <- pd %>% dplyr::filter(.data$term >= 11)
+  expect_gt(nrow(long_term_rows), 0)
+  expect_true(all(!is.na(long_term_rows$PD_baseline)))
+  expect_true(all(!is.na(long_term_rows$PD_late_sudden)))
+})


### PR DESCRIPTION
## Summary

- `calculate_pd_change_overall()` built a fixed per-company term grid (`1:5`, extended to `1:10` in fa32e62). Portfolio rows in trisk.analysis join on `(company_id, term)`; any portfolio term past the ceiling silently produced NA in the join (this is the bug ADO 1943 was tracking).
- Replace the hardcoded ceiling with `seq_len(end_of_analysis - start_year + 1)`. The analysis horizon is the principled cap: PD beyond the projection window has no economic basis here (terminal value handles beyond-horizon profits). Both parameters are already passed in, no API change.
- Add a regression test (`test_pd_term_grid.R`) covering: (1) new behaviour — `max(term)` matches horizon, (2) regression — `term ≥ 11` rows are populated when horizon allows it.

## Methodology note

`1:5 → 1:10 → horizon-sized` is the progression. Bank exposures with long maturities (real estate 15-30y, project finance 10-20y, long sovereign bonds) were dropping to NA under both prior ceilings; horizon-sized covers any analysis run that's long enough.

## Test plan

- [x] Regression test reproduces failure on `1:10` ceiling (3 fails on `HEAD~1`)
- [x] Regression test passes after fix (5/5 pass)
- [x] Existing tracked tests still pass (`terminal_value` 7/7, `output_continuity` skipped without `R_USE_TESTS=TRUE`)
- [ ] Run with `R_USE_TESTS=TRUE` in CI to confirm snapshot continuity holds (Merton math unchanged, just more rows in the grid — snapshot may need a refresh if it captures `nrow`)

## Caveats for reviewers

- An untracked WIP file `tests/testthat/test_input_validation.R` exists locally and fails 2 tests, unrelated to this change. Not included in the PR.
- The function still uses a per-company term grid rather than per-portfolio. The ADO 1943 comment makes clear that's intentional (PD trajectory describes overall trend, not portfolio-specific). This PR keeps that architecture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)